### PR TITLE
makefile should point at the main tex file. Merge after #1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-manuscript = main
+manuscript = 2021-bachmann-ans-annual
 references = $(wildcard *.bib)
 latexopt   = -halt-on-error -file-line-error
 


### PR DESCRIPTION
1 liner. Points the makefile at the correct `.tex` file. Don't merge until #1 is merged.